### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.tug.texworks.yaml
+++ b/org.tug.texworks.yaml
@@ -11,7 +11,12 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --device=dri
-  - --filesystem=host
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   - --env=TEXMFCACHE=$XDG_CACHE_HOME
   - --env=SESSION_MANAGER= # required to avoid Qt warning
   - --env=PATH=/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux:/app/bin:/usr/bin # required to find texlive binaries


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt