### PR TITLE
Update perl paths to make biblatex/biber work

### DIFF
--- a/org.tug.texworks.yaml
+++ b/org.tug.texworks.yaml
@@ -14,8 +14,8 @@ finish-args:
   - --env=TEXMFCACHE=$XDG_CACHE_HOME
 #  - --env=SESSION_MANAGER= # required to avoid Qt warning
   - --env=PATH=/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux:/app/bin:/usr/bin # required to find texlive binaries
-  - --env=LD_LIBRARY_PATH=/app/texlive/lib:/app/texlive/lib/perl5/5.38.0/x86_64-linux/CORE
-  - --env=PERL5LIB=/app/texlive/lib/perl5/5.38.0:/app/texlive/lib/perl5/site_perl/5.38.0
+  - --env=LD_LIBRARY_PATH=/app/texlive/lib:/app/texlive/lib/perl5/5.40.1/x86_64-linux/CORE
+  - --env=PERL5LIB=/app/texlive/lib/perl5/5.40.1:/app/texlive/lib/perl5/site_perl/5.40.1
 add-extensions:
   org.freedesktop.Sdk.Extension.texlive:
     version: '25.08'


### PR DESCRIPTION
The perl paths need to be updated to make perl work. As an alternative you could use a wrapper script as in https://github.com/flathub/org.texstudio.TeXstudio/blob/master/texstudio.sh or https://github.com/flathub/org.kde.kile/blob/master/kile.sh .